### PR TITLE
Syncer Performs One Action at a Time

### DIFF
--- a/Webresource.Syncer/Webresource.Syncer/Models/WebResoureceSyncerResponse.cs
+++ b/Webresource.Syncer/Webresource.Syncer/Models/WebResoureceSyncerResponse.cs
@@ -13,9 +13,8 @@ namespace WebResource.Syncer.Models
     {
         Create,
         Update,
-        AddedToSolution,
         Publish,
-        ListWebResourcesInSolution,
+        ListWebresourcesInSolution,
     }
     class Action
     {
@@ -24,7 +23,10 @@ namespace WebResource.Syncer.Models
         public bool Successful { get; set; }
         public string ErrorMessage { get; set; }
     }
-
+    internal class WebResoucePublishAction : Action
+    {
+        public string WebResourceName { get; set; }
+    }
     internal class WebResouceUploadAction : Action
     {
         public string WebResourceName { get; set; }
@@ -36,7 +38,6 @@ namespace WebResource.Syncer.Models
 
     internal class WebResoureceSyncerResponse
     {
-        public bool DryRun { get; set; }
-        public List<Action> ActionList { get; set; } = new List<Action>();
+        public Action Action { get; set; }
     }
 }

--- a/Webresource.Syncer/Webresource.Syncer/Program.cs
+++ b/Webresource.Syncer/Webresource.Syncer/Program.cs
@@ -1,78 +1,103 @@
-﻿using System.IO;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
+﻿#nullable enable
+using System.IO;
 using Microsoft.Extensions.Configuration;
-using WebResource.Syncer.Interface;
-using CommandLine;
 using WebResource.Syncer.SyncLogic;
-using Microsoft.Extensions.Logging.Console;
-using WebResource.Syncer;
-using System.Linq;
 using System.CommandLine;
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
-var fileOption = new Option<FileInfo?>(
-            name: "--file",
-            description: "The file path for the given action")
-{
-    IsRequired = true,
+IConfiguration config = new ConfigurationBuilder()
+        .AddJsonFile("appsettings.json", false)
+        .AddJsonFile("appsettings.Development.json", true)
+        .Build();
 
-};
+var uploadFunc = async (FileInfo file, string solutionName, bool updateIfExists, string? connectionString) => 
+    await (new Uploader(config, file, solutionName, updateIfExists, connectionString)).UploadFileAsync();
 
-var solutionOption = new Option<string?>(
-    name: "--solution",
-    description: "Logical name of solution for the given action")
-{
-    IsRequired = true,
-};
+var listFunc = async (string solutionName, string? connectionString) => 
+    await (new Lister(config, solutionName, connectionString)).ListFilesInSolutionAsync();
 
-var updateIfExistsOption = new Option<bool>(
-    name: "--update-if-exists",
-    getDefaultValue: () => false,
-    description: "If the file already exists in the solution, update it's content");
+var publishFunc = async (FileInfo file, string? connectionString) => 
+    await (new Publisher(config, file, connectionString)).PublishFileAsync();
 
-var rootCommand = new RootCommand("Webresource.Syncer");
-
-var uploadCommand = new Command("upload", "Upload the file to PowerApps")
-            {
-                fileOption,
-                solutionOption,
-                updateIfExistsOption,
-            };
-
-var listCommand = new Command("list", "List the Webresources in a given solution")
-{
-    solutionOption,
-};
-
-var publishCommand = new Command("publish", "Publish Webresource in PowerApps")
-{
-    fileOption,
-};
-
-uploadCommand.SetHandler(async (FileInfo fileInfo, string solutionName, bool updateIfExists) =>
-{
-    Console.WriteLine(fileInfo);
-    Console.WriteLine(solutionName);
-    Console.WriteLine(updateIfExists);
-}, fileOption, solutionOption, updateIfExistsOption);
-
-listCommand.SetHandler(async (string solutionName) =>
-{
-    Console.WriteLine(solutionName);
-}, solutionOption);
-
-
-publishCommand.SetHandler(async (FileInfo fileInfo) =>
-{
-    Console.WriteLine(fileInfo);
-}, fileOption);
-
-rootCommand.AddCommand(uploadCommand);
-rootCommand.AddCommand(listCommand);
-rootCommand.AddCommand(publishCommand);
+var rootCommand = GenerateCommandLineArguments(uploadFunc, listFunc, publishFunc);
 
 return rootCommand.InvokeAsync(args).Result;
+
+static RootCommand GenerateCommandLineArguments(
+    Func<FileInfo, string, bool, string?, Task<string>> uploadFuncAsync,
+    Func<string, string?, Task<string>> listFuncAsync,
+    Func<FileInfo, string?, Task<string>> publishFuncAsync
+    )
+{
+    var connStringOption = new Option<string?>(
+        name: "--conn-string",
+        description: "Connection string to authenticate with Power Apps")
+    {
+    };
+
+    var fileOption = new Option<FileInfo?>(
+        name: "--file",
+        description: "The file path for the given action")
+    {
+        IsRequired = true,
+    };
+
+    var solutionOption = new Option<string?>(
+        name: "--solution",
+        description: "Logical name of solution for the given action")
+    {
+        IsRequired = true,
+    };
+
+    var updateIfExistsOption = new Option<bool>(
+        name: "--update-if-exists",
+        getDefaultValue: () => false,
+        description: "If the file already exists in the solution, update it's content");
+
+
+    var uploadCommand = new Command("upload", "Upload the file to PowerApps")
+    {
+        fileOption,
+        solutionOption,
+        updateIfExistsOption,
+        connStringOption,
+    };
+
+    var listCommand = new Command("list", "List the Webresources in a given solution")
+    {
+        solutionOption,
+        connStringOption,
+    };
+
+    var publishCommand = new Command("publish", "Publish Webresource in PowerApps")
+    {
+        fileOption,
+        connStringOption,
+    };
+
+    uploadCommand.SetHandler(async (FileInfo fileInfo, string solutionName, bool updateIfExists, string connectionString) =>
+    {
+        Console.WriteLine(await uploadFuncAsync(fileInfo, solutionName, updateIfExists, connectionString));
+    }, fileOption, solutionOption, updateIfExistsOption, connStringOption);
+
+    listCommand.SetHandler(async (string solutionName, string connectionString) =>
+    {
+        Console.WriteLine(await listFuncAsync(solutionName, connectionString));
+    }, solutionOption, connStringOption);
+
+
+    publishCommand.SetHandler(async (FileInfo fileInfo, string connectionString) =>
+    {
+        Console.WriteLine(await publishFuncAsync(fileInfo, connectionString));
+    }, fileOption, connStringOption);
+
+    var rootCommand = new RootCommand("Webresource.Syncer");
+
+    rootCommand.AddCommand(uploadCommand);
+    rootCommand.AddCommand(listCommand);
+    rootCommand.AddCommand(publishCommand);
+
+    return rootCommand;
+}
 

--- a/Webresource.Syncer/Webresource.Syncer/Program.cs
+++ b/Webresource.Syncer/Webresource.Syncer/Program.cs
@@ -7,25 +7,72 @@ using CommandLine;
 using WebResource.Syncer.SyncLogic;
 using Microsoft.Extensions.Logging.Console;
 using WebResource.Syncer;
+using System.Linq;
+using System.CommandLine;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
-await Parser.Default.ParseArguments<CommandLineOptions>(args).WithParsedAsync(async options =>
+var fileOption = new Option<FileInfo?>(
+            name: "--file",
+            description: "The file path for the given action")
 {
-    IConfiguration config = new ConfigurationBuilder()
-        .AddJsonFile("appsettings.json", false)
-        .AddJsonFile("appsettings.Development.json", true)
-        .Build();
+    IsRequired = true,
 
-    if (options.ListWebResources)
-    {
-        var lister = new Lister(config, options);
+};
 
-        await lister.ListFilesInSolutionAsync();
+var solutionOption = new Option<string?>(
+    name: "--solution",
+    description: "Logical name of solution for the given action")
+{
+    IsRequired = true,
+};
 
-        return;
-    }
+var updateIfExistsOption = new Option<bool>(
+    name: "--update-if-exists",
+    getDefaultValue: () => false,
+    description: "If the file already exists in the solution, update it's content");
 
-    IUploader uploader = new Uploader(config, options);
+var rootCommand = new RootCommand("Webresource.Syncer");
 
-    await uploader.UploadFileAsync();
+var uploadCommand = new Command("upload", "Upload the file to PowerApps")
+            {
+                fileOption,
+                solutionOption,
+                updateIfExistsOption,
+            };
 
-});
+var listCommand = new Command("list", "List the Webresources in a given solution")
+{
+    solutionOption,
+};
+
+var publishCommand = new Command("publish", "Publish Webresource in PowerApps")
+{
+    fileOption,
+};
+
+uploadCommand.SetHandler(async (FileInfo fileInfo, string solutionName, bool updateIfExists) =>
+{
+    Console.WriteLine(fileInfo);
+    Console.WriteLine(solutionName);
+    Console.WriteLine(updateIfExists);
+}, fileOption, solutionOption, updateIfExistsOption);
+
+listCommand.SetHandler(async (string solutionName) =>
+{
+    Console.WriteLine(solutionName);
+}, solutionOption);
+
+
+publishCommand.SetHandler(async (FileInfo fileInfo) =>
+{
+    Console.WriteLine(fileInfo);
+}, fileOption);
+
+rootCommand.AddCommand(uploadCommand);
+rootCommand.AddCommand(listCommand);
+rootCommand.AddCommand(publishCommand);
+
+return rootCommand.InvokeAsync(args).Result;
+

--- a/Webresource.Syncer/Webresource.Syncer/Properties/launchSettings.json
+++ b/Webresource.Syncer/Webresource.Syncer/Properties/launchSettings.json
@@ -2,11 +2,19 @@
   "profiles": {
     "WebResource.Syncer - Test Upload": {
       "commandName": "Project",
-      "commandLineArgs": "--filePath c:\\Users\\JohnYenter-Briars\\hackathon\\dev\\test.js --solution vscodeextentiontest --publish --updateIfExists"
+      "commandLineArgs": "upload --file c:\\Users\\JohnYenter-Briars\\hackathon\\dev\\test2.js --solution vscodeextentiontest"
+    },
+    "WebResource.Syncer - Test Upload (Update if Exists)": {
+      "commandName": "Project",
+      "commandLineArgs": "upload --file c:\\Users\\JohnYenter-Briars\\hackathon\\dev\\test2.js --solution vscodeextentiontest --update-if-exists"
     },
     "WebResource.Syncer - Test List Files": {
       "commandName": "Project",
-      "commandLineArgs": "--solution vscodeextentiontest --listWebResources"
+      "commandLineArgs": "list --solution vscodeextentiontest"
+    },
+    "WebResource.Syncer - Test Publish File": {
+      "commandName": "Project",
+      "commandLineArgs": "publish --file c:\\Users\\JohnYenter-Briars\\hackathon\\dev\\test2.js"
     }
   }
 }

--- a/Webresource.Syncer/Webresource.Syncer/SyncLogic/Publisher.cs
+++ b/Webresource.Syncer/Webresource.Syncer/SyncLogic/Publisher.cs
@@ -1,0 +1,67 @@
+﻿#nullable enable
+using Microsoft.Crm.Sdk.Messages;
+using Microsoft.Extensions.Configuration;
+using Microsoft.PowerPlatform.Dataverse.Client;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using WebResource.Syncer.Models;
+using System.IO;
+
+namespace WebResource.Syncer.SyncLogic
+{
+    class Publisher
+    {
+        private readonly ServiceClient ServiceClient;
+        private readonly FileInfo File;
+        private readonly JsonSerializerSettings JsonSerializerSettings = new()
+        {
+            ContractResolver = new DefaultContractResolver
+            {
+                NamingStrategy = new CamelCaseNamingStrategy(),
+            },
+        };
+
+        public Publisher(IConfiguration configuration, FileInfo file, string? connectionString)
+        {
+            ServiceClient = string.IsNullOrEmpty(connectionString) ?
+                                new ServiceClient(configuration["ConnectionString"]) :
+                                new ServiceClient(connectionString);
+            File = file;
+        }
+        public async Task<string> PublishFileAsync()
+        {
+            var responseObject = new WebResoureceSyncerResponse();
+            var wr = new Models.WebResource(@$"{File.FullName}");
+
+            var listOfWebResources = new List<Models.WebResource> { wr };
+
+            await Publish(listOfWebResources, ServiceClient);
+            responseObject.ActionList.Add(new WebResouceUploadAction
+            {
+                WebResourceName = wr.Name,
+                ActionName = ActionName.Publish,
+                Successful = true,
+            });
+
+            return JsonConvert.SerializeObject(responseObject, JsonSerializerSettings);
+        }
+        private static async Task Publish(List<Models.WebResource> webresources, ServiceClient service)
+        {
+            string idsAsXML = string.Empty;
+
+            foreach (Models.WebResource webresource in webresources)
+            {
+                idsAsXML += $"<webresource>{webresource.Id:B}</webresource>";
+            }
+
+            var publishRequest = new PublishXmlRequest
+            {
+                ParameterXml = $"<importexportxml><webresources>{idsAsXML}</webresources></importexportxml>"
+            };
+
+            await service.ExecuteAsync(publishRequest);
+        }
+    }
+}

--- a/Webresource.Syncer/Webresource.Syncer/Webresource.Syncer.csproj
+++ b/Webresource.Syncer/Webresource.Syncer/Webresource.Syncer.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="0.5.17" />
     <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client.Dynamics" Version="0.5.17" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta3.22114.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
 				"category": "Webber"
 			},
 			{
-				"command": "webber.uploadAndPublishFile",
-				"title": "Upload and publish file to Power Apps",
+				"command": "webber.publishFile",
+				"title": "Publish file to Power Apps",
 				"category": "Webber"
 			}
 		],
@@ -46,7 +46,7 @@
 					"group": "navigation"
 				},
 				{
-					"command": "webber.uploadAndPublishFile",
+					"command": "webber.publishFile",
 					"group": "navigation"
 				}
 			]

--- a/src/classes/syncer/WebResourceSyncer.ts
+++ b/src/classes/syncer/WebResourceSyncer.ts
@@ -40,7 +40,7 @@ export class WebResourceSyncer {
 		id: string;
 	}[]> {
 		let asyncFunc = async (solutionName: string) => {
-			const args = ['--solution', solutionName, '--listWebResources',];
+			const args = ['list', '--solution', solutionName,];
 
 			const procResult = await this._execFile(this._exePath, args, {
 				shell: true,
@@ -49,23 +49,22 @@ export class WebResourceSyncer {
 
 			let response: WebResoureceSyncerResponse = JSON.parse(procResult.stdout);
 
-			if (response.dryRun) {
-				await vscode.window.showInformationMessage("Dry run successful");
-				return Promise.resolve([]);
+			let string = `Action: ${response.action.actionName}. Successful: ${response.action.successful}. ` 
+							+ (response.action.successful ? "" : `Error message: ${response.action.errorMessage}`);
+
+			if (response.action.successful) {
+				vscode.window.showInformationMessage(string);
+			} else {
+				vscode.window.showErrorMessage(string, "Rerun this action?");
 			}
 
-			for (let action of response.actionList) {
-				let string = `Stage: ${action.actionName}. Successful: ${action.successful}. ` + (action.successful ? "" : `Error message: ${action.errorMessage}`);
-				vscode.window.showInformationMessage(string, "Reun this stage?");
+			if (response.action.actionName === "ListWebresourcesInSolution") {
+				let listAction = response.action as ListWebResourcesInSolutionAction;
 
-				if (action.actionName === "ListWebResourcesInSolution") {
-					let listAction = action as ListWebResourcesInSolutionAction;
-
-					return listAction.webResources;
-				}
+				return listAction.webResources;
+			} else {
+				throw new Error("No ListWebResourceAction found?");
 			}
-
-			throw new Error("No ListWebResourceAction found?");
 		};
 
 		return await this.reportProgress<{
@@ -74,13 +73,13 @@ export class WebResourceSyncer {
 		}[]>("Fetching Webresources...", asyncFunc, solutionName);
 	}
 
-	async uploadFile(solutionName: string, path: string, publish: boolean = false) {
+	async uploadFile(solutionName: string, path: string, updateIfExists: boolean = false) {
 
-		let asyncFunc = async (solutionName: string, path: string, publish: boolean) => {
-			const args = ['--filePath', path, '--solution', solutionName, '--updateIfExists',];
+		let asyncFunc = async (solutionName: string, path: string, updateIfExists: boolean) => {
+			const args = ['upload', '--file', path, '--solution', solutionName,];
 
-			if (publish) {
-				args.push('--publish');
+			if (updateIfExists) {
+				args.push('--update-if-exists');
 			}
 
 			const procResult = await this._execFile(this._exePath, args, {
@@ -90,17 +89,41 @@ export class WebResourceSyncer {
 
 			let response: WebResoureceSyncerResponse = JSON.parse(procResult.stdout);
 
-			if (response.dryRun) {
-				await vscode.window.showInformationMessage("Dry run successful");
-				return;
-			}
+			let string = `Action: ${response.action.actionName}. Successful: ${response.action.successful}. ` 
+							+ (response.action.successful ? "" : `Error message: ${response.action.errorMessage}`);
 
-			for (let action of response.actionList) {
-				let string = `Stage: ${action.actionName}. Successful: ${action.successful}. ` + (action.successful ? "" : `Error message: ${action.errorMessage}`);
-				vscode.window.showInformationMessage(string, "Reun this stage?");
+			if (response.action.successful) {
+				vscode.window.showInformationMessage(string);
+			} else {
+				vscode.window.showErrorMessage(string, "Rerun this action?");
 			}
 		};
 
-		await this.reportProgress("Uploading Webresource...", asyncFunc, solutionName, path, publish);
+		await this.reportProgress("Uploading Webresource...", asyncFunc, solutionName, path, updateIfExists);
+	}
+
+	async publishFile(path: string) {
+
+		let asyncFunc = async (path: string) => {
+			const args = ['publish', '--file', path];
+
+			const procResult = await this._execFile(this._exePath, args, {
+				shell: true,
+				windowsHide: true,
+			});
+
+			let response: WebResoureceSyncerResponse = JSON.parse(procResult.stdout);
+
+			let string = `Action: ${response.action.actionName}. Successful: ${response.action.successful}. ` 
+							+ (response.action.successful ? "" : `Error message: ${response.action.errorMessage}`);
+
+			if (response.action.successful) {
+				vscode.window.showInformationMessage(string);
+			} else {
+				vscode.window.showErrorMessage(string, "Rerun this action?");
+			}
+		};
+
+		await this.reportProgress("Publishing Webresource...", asyncFunc, path);
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,12 +23,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	vscode.commands.registerCommand('webber.uploadFile', async (resource: vscode.Uri) => {
 		const solutionName = WebResourceSyncerConfiguration.getSolution();
-		await syncer.uploadFile(solutionName, resource.fsPath);
+		await syncer.uploadFile(solutionName, resource.fsPath, true);
 	});
 
-	vscode.commands.registerCommand('webber.uploadAndPublishFile', async (resource: vscode.Uri) => {
-		const solutionName = WebResourceSyncerConfiguration.getSolution();
-		await syncer.uploadFile(solutionName, resource.fsPath, true);
+	vscode.commands.registerCommand('webber.publishFile', async (resource: vscode.Uri) => {
+		await syncer.publishFile(resource.fsPath);
 	});
 
 	vscode.commands.registerCommand('test.view.showError', async (item: WebResource) => {

--- a/src/models/webresourcesyncerresponse.ts
+++ b/src/models/webresourcesyncerresponse.ts
@@ -14,6 +14,5 @@ export interface ListWebResourcesInSolutionAction extends Action {
 }
 
 export interface WebResoureceSyncerResponse {
-    actionList: Action[];
-    dryRun: boolean;
+    action: Action;
 }


### PR DESCRIPTION
- refac `Syncer` to have a more modular and user-friendly CLI
- split `Syncer` up into component parts, one execution of the exe corresponds with only one action
- stops and reports to user on first failure
- reflect API changes on extension's end