### PR TITLE
Dont activate without package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Change Log
 
-All notable changes to the "powerapps-wre" extension will be documented in this file.
-
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
-
 ## [Unreleased]
 
-- Initial release
+- Initial proof of concept
+
+## [0.1.0]
+
+- Read solution and connection string from package.json
+- Create and Update Webresources to PowerApps
+- Optionally publish 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,31 @@
 # Powerapps-WRE README
 
-Under construction! Please bear with us
+Welcome to the XXX extension for Visual Studio Code! This extension provides the following features inside VS Code:
+
+- Create or Update Webresources in PowerApps straight from VS Code.
+- Publish Webresourecs automatically
+
+### Getting Started with XXX
+- Install the extesion at: [LINK](google.com)
+- Add a `package.json` at the root of your project with the following parameters
+```
+{
+    ...
+    "solutionName": "<your-solution-name>",
+    "connectionString": "<your-connection-string>",
+    ...
+}
+```
+- Open up the folder which holds your Webresources in VS Code
+
+
+### Creating a Webresource
+- Right click on a item in the file tree you would like to create
+- Select if you would like to publish the file as well
+- Input the name the logical name of the Webresource  
+
+### Updating a Webresource
+- Right click on an item in the file tree you would like to update
+- Select if you would like to publish the updated file as well
+- Select the file in the current solution you would like to update the contents
+

--- a/Webresource.Syncer/Webresource.Syncer/Program.cs
+++ b/Webresource.Syncer/Webresource.Syncer/Program.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 
 IConfiguration config = new ConfigurationBuilder()
         .AddJsonFile("appsettings.json", false)
-        .AddJsonFile("appsettings.Development.json", true)
         .Build();
 
 var uploadFunc = async (FileInfo file, string solutionName, bool updateIfExists, string? connectionString) => 
@@ -34,6 +33,7 @@ static RootCommand GenerateCommandLineArguments(
         name: "--conn-string",
         description: "Connection string to authenticate with Power Apps")
     {
+        IsRequired = true,
     };
 
     var fileOption = new Option<FileInfo?>(

--- a/Webresource.Syncer/Webresource.Syncer/Webresource.Syncer.csproj
+++ b/Webresource.Syncer/Webresource.Syncer/Webresource.Syncer.csproj
@@ -30,7 +30,7 @@
 
   <ItemGroup>
     <None Update="appsettings.Development.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </None>
     <None Update="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/src/classes/syncer/WebResourceSyncer.ts
+++ b/src/classes/syncer/WebResourceSyncer.ts
@@ -8,8 +8,7 @@ export class WebResourceSyncer {
 	_exePath: string;
 	_execFile: Function;
 
-
-	constructor(exePath: string) {
+	constructor(exePath: string, private connString: string) {
 		this._exePath = exePath;
 		this._execFile = util.promisify(require('child_process').execFile);
 	}
@@ -38,7 +37,7 @@ export class WebResourceSyncer {
 		id: string;
 	}[]> {
 		let asyncFunc = async (solutionName: string) => {
-			const args = ['list', '--solution', solutionName,];
+			const args = ['list', '--solution', solutionName, '--conn-string', this.connString];
 
 			const procResult = await this._execFile(this._exePath, args, {
 				shell: true,
@@ -74,7 +73,7 @@ export class WebResourceSyncer {
 	async uploadFile(solutionName: string, path: string, updateIfExists: boolean = false) {
 
 		let asyncFunc = async (solutionName: string, path: string, updateIfExists: boolean) => {
-			const args = ['upload', '--file', path, '--solution', solutionName,];
+			const args = ['upload', '--file', path, '--solution', solutionName, '--conn-string', this.connString];
 
 			if (updateIfExists) {
 				args.push('--update-if-exists');
@@ -103,7 +102,7 @@ export class WebResourceSyncer {
 	async publishFile(path: string) {
 
 		let asyncFunc = async (path: string) => {
-			const args = ['publish', '--file', path];
+			const args = ['publish', '--file', path, '--conn-string', this.connString];
 
 			const procResult = await this._execFile(this._exePath, args, {
 				shell: true,

--- a/src/classes/syncer/WebResourceSyncerConfiguration.ts
+++ b/src/classes/syncer/WebResourceSyncerConfiguration.ts
@@ -1,6 +1,21 @@
 import * as vscode from 'vscode';
 
 export abstract class WebResourceSyncerConfiguration {
+	public static async currentWorkspaceHasConfigFile(): Promise<boolean> {
+		if (vscode.workspace.workspaceFolders === undefined) {
+			throw new Error("Cannot activate extension. Workspace is undefined");
+		}
+
+		const fileName = 'package.json';
+		const workspacePath = vscode.workspace.workspaceFolders[0].uri.path;
+
+		try {
+			await vscode.workspace.fs.stat(vscode.Uri.file(workspacePath + '/' + fileName));
+			return true;
+		} catch (error) {
+			return false;
+		}
+	}
 	public static async getConfigFileAsJson(): Promise<any> {
 		if (vscode.workspace.workspaceFolders === undefined) {
 			throw new Error("Cannot activate extension. Workspace is undefined");

--- a/src/classes/syncer/WebResourceSyncerConfiguration.ts
+++ b/src/classes/syncer/WebResourceSyncerConfiguration.ts
@@ -24,6 +24,7 @@ export abstract class WebResourceSyncerConfiguration {
 		if (json.hasOwnProperty(propertyName)) {
 			return json[propertyName];
 		} else {
+			vscode.window.showErrorMessage(`No property named ${propertyName} in package.json`);
 			throw new Error(`No property named ${propertyName} in package.json`);
 		}
 	}
@@ -34,6 +35,7 @@ export abstract class WebResourceSyncerConfiguration {
 		if (json.hasOwnProperty(propertyName)) {
 			return json[propertyName];
 		} else {
+			vscode.window.showErrorMessage(`No property named ${propertyName} in package.json`);
 			throw new Error(`No property named ${propertyName} in package.json`);
 		}
 	}
@@ -44,6 +46,7 @@ export abstract class WebResourceSyncerConfiguration {
 		if (json.hasOwnProperty(propertyName)) {
 			return json[propertyName];
 		} else {
+			vscode.window.showErrorMessage(`No property named ${propertyName} in package.json`);
 			throw new Error(`No property named ${propertyName} in package.json`);
 		}
 	}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,12 @@ import { WebResourceSyncerConfiguration } from './classes/syncer/WebResourceSync
 const syncerExePath = "/WebResource.Syncer/WebResource.Syncer/bin/Release/net6.0/WebResource.Syncer.exe";
 
 export async function activate(context: vscode.ExtensionContext) {
+	if (! await WebResourceSyncerConfiguration.currentWorkspaceHasConfigFile())
+	{
+		vscode.window.showErrorMessage(`There is no package.json in the root of the current workspace! Please add one with the properties: 'connectionString' and 'solutionName', and then refresh the extension by running the command: '>Reload Window'`);
+		return;
+	}
+
 	let syncer = new WebResourceSyncer(context.extensionPath + syncerExePath, await WebResourceSyncerConfiguration.getConnectionString());
 
 	const solutionName = await WebResourceSyncerConfiguration.getSolution();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import { WebResourceSyncerConfiguration } from './classes/syncer/WebResourceSync
 const syncerExePath = "/WebResource.Syncer/WebResource.Syncer/bin/Release/net6.0/WebResource.Syncer.exe";
 
 export async function activate(context: vscode.ExtensionContext) {
-	let syncer = new WebResourceSyncer(context.extensionPath + syncerExePath);
+	let syncer = new WebResourceSyncer(context.extensionPath + syncerExePath, await WebResourceSyncerConfiguration.getConnectionString());
 
 	const solutionName = await WebResourceSyncerConfiguration.getSolution();
 	let resources = await syncer.retreiveWebResourcesInSolution(solutionName);


### PR DESCRIPTION
- make connection string a required input
- remove inclusion of `appsettings.Development.json` @plohm12  and @vuciv this will required you to pass in the connection string manually through `launchSettings.json`
- dont activate extension if no `package.json` 
- 1711